### PR TITLE
Fix geolocation API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Dynamic CSS animations respond to threat levels:
 - **Cost**: Free tier, no API key required
 
 ### Geolocation (IP-API)
-- **Endpoint**: `https://ip-api.com/json/`
+- **Endpoint**: `http://ip-api.com/json/`
 - **Data**: City, country, coordinates, ISP information
 - **Update Frequency**: Once per session
 - **Cost**: Free tier, no API key required

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -100,7 +100,7 @@ class APIService {
 
   async fetchGeolocationData(): Promise<GeolocationData | null> {
     try {
-      const response = await fetch('https://ip-api.com/json/');
+      const response = await fetch('http://ip-api.com/json/');
       const data = await response.json();
       
       if (data.status === 'success') {


### PR DESCRIPTION
## Summary
- use HTTP endpoint for IP-API geolocation
- document new endpoint in README

## Testing
- `npm install`
- `npm run build`


------
